### PR TITLE
[#10] 로그인/로그아웃 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -53,6 +53,9 @@ YOUSINSA REST API에서 사용하는 HTTP Method는 REST 방식으로 작성되�
 | `204 No Content`
 | 기존 리소스를 성공적으로 수정함.
 
+| `205 Reset Content`
+| 컨텐츠의 갱신이 필요함.
+
 | `400 Bad Request`
 | 잘못된 요청을 보낸 경우. 응답 본문에 더 오류에 대한 정보가 담겨있다.
 
@@ -60,9 +63,16 @@ YOUSINSA REST API에서 사용하는 HTTP Method는 REST 방식으로 작성되�
 | 요청한 리소스가 없음.
 |===
 
-== User
+== User-API
 
 === SignUp
 
 operation::user-signup[snippets='curl-request,http-request,http-response,request-body,request-fields,response-body,response-fields']
 
+=== SignIn
+
+operation::user-signin[snippets='curl-request,http-request,http-response,request-body,request-fields,response-body,response-fields']
+
+=== SignOut
+
+operation::user-signout[snippets='curl-request,http-request,http-response']

--- a/src/main/java/com/flab/yousinsa/user/config/AuthWebConfig.java
+++ b/src/main/java/com/flab/yousinsa/user/config/AuthWebConfig.java
@@ -1,0 +1,22 @@
+package com.flab.yousinsa.user.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.flab.yousinsa.user.controller.interceptor.AuthUserInterceptor;
+
+@Configuration
+public class AuthWebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new AuthUserInterceptor())
+			.addPathPatterns("/**")
+			.excludePathPatterns("/**/users/sign-up", "/**/users/sign-in");
+	}
+
+	public static class Session {
+		public static final String AUTH_USER = "AuthUser";
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/config/SecurityConfig.java
+++ b/src/main/java/com/flab/yousinsa/user/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.flab.yousinsa.user.service.config;
+package com.flab.yousinsa.user.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/flab/yousinsa/user/controller/api/UserController.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/api/UserController.java
@@ -1,29 +1,73 @@
 package com.flab.yousinsa.user.controller.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.flab.yousinsa.user.config.AuthWebConfig.Session.*;
+
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
+import com.flab.yousinsa.user.domain.dtos.request.SignInRequestDto;
 import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
+import com.flab.yousinsa.user.domain.dtos.response.SignInResponseDto;
 import com.flab.yousinsa.user.domain.dtos.response.SignUpResponseDto;
+import com.flab.yousinsa.user.service.contract.UserSignInService;
 import com.flab.yousinsa.user.service.contract.UserSignUpService;
+import com.flab.yousinsa.user.service.exception.SignOutFailException;
+
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
+@Slf4j
 public class UserController {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(UserController.class);
-	private final UserSignUpService userService;
+	private final UserSignUpService userSignUpService;
+	private final UserSignInService userSignInService;
 
-	public UserController(UserSignUpService userService) {
-		this.userService = userService;
+	public UserController(UserSignUpService userSignUpService, UserSignInService userSignInService) {
+		this.userSignUpService = userSignUpService;
+		this.userSignInService = userSignInService;
 	}
 
-	@PostMapping("api/v1/users")
-	public ResponseEntity<SignUpResponseDto> signUpUser(@RequestBody SignUpRequestDto signUpRequest) {
-		SignUpResponseDto signUpResponse = userService.trySignUpUser(signUpRequest);
+	@PostMapping("api/v1/users/sign-up")
+	public ResponseEntity<SignUpResponseDto> signUpUser(@Valid @RequestBody SignUpRequestDto signUpRequest) {
+		SignUpResponseDto signUpResponse = userSignUpService.trySignUpUser(signUpRequest);
 		return ResponseEntity.ok(signUpResponse);
+	}
+
+	@PostMapping("api/v1/users/sign-in")
+	public ResponseEntity<SignInResponseDto> signInUser(@Valid @RequestBody SignInRequestDto signInRequestDto,
+		HttpSession httpSession) {
+		SignInResponseDto signInResponseDto = userSignInService.trySignInUser(signInRequestDto);
+		AuthUser authUser = new AuthUser(
+			signInResponseDto.getId(),
+			signInResponseDto.getUserName(),
+			signInResponseDto.getUserEmail(),
+			signInResponseDto.getUserRole()
+		);
+		httpSession.setAttribute(AUTH_USER, authUser);
+
+		return ResponseEntity.ok(signInResponseDto);
+	}
+
+	@DeleteMapping("api/v1/users/sign-out")
+	public ResponseEntity<Void> signOutUser(HttpSession httpSession) {
+		try {
+			httpSession.invalidate();
+		} catch (IllegalStateException e) {
+			if (log.isErrorEnabled()) {
+				log.error("User already signed out", e);
+			}
+
+			throw new SignOutFailException("User already signed out", e);
+		}
+
+		return ResponseEntity.status(HttpStatus.RESET_CONTENT).build();
 	}
 }

--- a/src/main/java/com/flab/yousinsa/user/controller/interceptor/AuthUserInterceptor.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/interceptor/AuthUserInterceptor.java
@@ -1,0 +1,47 @@
+package com.flab.yousinsa.user.controller.interceptor;
+
+import static com.flab.yousinsa.user.config.AuthWebConfig.Session.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.flab.yousinsa.user.service.exception.AuthException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class AuthUserInterceptor implements HandlerInterceptor {
+
+	/**
+	 * Session을 통한 User Auth Check
+	 * - 회원 가입, 로그인을 제외한 Handler에 필요한 Authenication 작업을 Interceptor로 처리
+	 * - AOP 방식과 Interceptor 방식 고려
+	 * - Interceptor 선정
+	 * - Spring Security에서는 Filter를 통한 Authentication 지원
+	 *
+	 * @param request
+	 * @param response
+	 * @param handler
+	 * @return
+	 * @throws AuthException
+	 */
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+
+		HttpSession session = request.getSession(false);
+		if (session == null) {
+			log.debug("There is no session");
+			throw new AuthException("Need to login for using this service");
+		}
+
+		Object authUser = session.getAttribute(AUTH_USER);
+
+		return authUser != null;
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/domain/dtos/AuthUser.java
+++ b/src/main/java/com/flab/yousinsa/user/domain/dtos/AuthUser.java
@@ -1,0 +1,33 @@
+package com.flab.yousinsa.user.domain.dtos;
+
+import com.flab.yousinsa.user.domain.enums.UserRole;
+
+public class AuthUser {
+	private Long id;
+	private String userName;
+	private String userEmail;
+	private UserRole userRole;
+
+	public AuthUser(Long id, String userName, String userEmail, UserRole userRole) {
+		this.id = id;
+		this.userName = userName;
+		this.userEmail = userEmail;
+		this.userRole = userRole;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public String getUserEmail() {
+		return userEmail;
+	}
+
+	public UserRole getUserRole() {
+		return userRole;
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/domain/dtos/request/SignInRequestDto.java
+++ b/src/main/java/com/flab/yousinsa/user/domain/dtos/request/SignInRequestDto.java
@@ -1,0 +1,31 @@
+package com.flab.yousinsa.user.domain.dtos.request;
+
+import javax.validation.constraints.NotEmpty;
+
+public class SignInRequestDto {
+
+	@NotEmpty
+	private String userEmail;
+	@NotEmpty
+	private String userPassword;
+
+	public SignInRequestDto() {
+	}
+
+	public SignInRequestDto(String userEmail, String userPassword) {
+		this.userEmail = userEmail;
+		this.userPassword = userPassword;
+	}
+
+	public String getUserEmail() {
+		return userEmail;
+	}
+
+	public String getUserPassword() {
+		return userPassword;
+	}
+
+	public void setUserPassword(String userPassword) {
+		this.userPassword = userPassword;
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/domain/dtos/request/SignUpRequestDto.java
+++ b/src/main/java/com/flab/yousinsa/user/domain/dtos/request/SignUpRequestDto.java
@@ -1,13 +1,21 @@
 package com.flab.yousinsa.user.domain.dtos.request;
 
+import javax.validation.constraints.NotEmpty;
+
 import com.flab.yousinsa.user.domain.enums.UserRole;
 
 public class SignUpRequestDto {
 
+	@NotEmpty
 	private String userName;
+
+	@NotEmpty
 	private String userEmail;
+
+	@NotEmpty
 	private String userPassword;
-	private UserRole userRole;
+
+	private UserRole userRole = UserRole.BUYER;
 
 	public SignUpRequestDto() {
 	}

--- a/src/main/java/com/flab/yousinsa/user/domain/dtos/response/SignInResponseDto.java
+++ b/src/main/java/com/flab/yousinsa/user/domain/dtos/response/SignInResponseDto.java
@@ -1,0 +1,37 @@
+package com.flab.yousinsa.user.domain.dtos.response;
+
+import com.flab.yousinsa.user.domain.enums.UserRole;
+
+public class SignInResponseDto {
+
+	private UserRole userRole;
+	private Long id;
+	private String userName;
+	private String userEmail;
+
+	public SignInResponseDto() {
+	}
+
+	public SignInResponseDto(Long id, String userName, String userEmail, UserRole userRole) {
+		this.id = id;
+		this.userName = userName;
+		this.userEmail = userEmail;
+		this.userRole = userRole;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public String getUserEmail() {
+		return userEmail;
+	}
+
+	public UserRole getUserRole() {
+		return userRole;
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/domain/enums/UserRole.java
+++ b/src/main/java/com/flab/yousinsa/user/domain/enums/UserRole.java
@@ -1,7 +1,7 @@
 package com.flab.yousinsa.user.domain.enums;
 
 public enum UserRole {
-    BUYER,
-    STORE_OWNER,
-    ADMIN,
+	BUYER,
+	STORE_OWNER,
+	ADMIN,
 }

--- a/src/main/java/com/flab/yousinsa/user/repository/contract/UserRepository.java
+++ b/src/main/java/com/flab/yousinsa/user/repository/contract/UserRepository.java
@@ -1,14 +1,16 @@
 package com.flab.yousinsa.user.repository.contract;
 
-import com.flab.yousinsa.user.domain.entities.UserEntity;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.yousinsa.user.domain.entities.UserEntity;
 
 @Repository
 @Transactional
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
-    Optional<UserEntity> findByUserEmail(String userEmail);
+	Optional<UserEntity> findByUserEmail(String userEmail);
 }

--- a/src/main/java/com/flab/yousinsa/user/service/CustomCryptPasswordEncoder.java
+++ b/src/main/java/com/flab/yousinsa/user/service/CustomCryptPasswordEncoder.java
@@ -5,12 +5,11 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class CustomCryptPasswordEncoder implements PasswordEncoder {
 
-	private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
 	private final String SHA_512 = "SHA-512";
 
 	@Override
@@ -33,7 +32,7 @@ public class CustomCryptPasswordEncoder implements PasswordEncoder {
 			digest.update(rawPassword.getBytes(StandardCharsets.UTF_8));
 			hashedPassword = Arrays.toString(digest.digest());
 		} catch (NoSuchAlgorithmException e) {
-			logger.error("There is no such " + algorithm, e);
+			log.error("There is no such " + algorithm, e);
 			throw new RuntimeException(e);
 		}
 

--- a/src/main/java/com/flab/yousinsa/user/service/contract/UserSignInService.java
+++ b/src/main/java/com/flab/yousinsa/user/service/contract/UserSignInService.java
@@ -1,0 +1,8 @@
+package com.flab.yousinsa.user.service.contract;
+
+import com.flab.yousinsa.user.domain.dtos.request.SignInRequestDto;
+import com.flab.yousinsa.user.domain.dtos.response.SignInResponseDto;
+
+public interface UserSignInService {
+	SignInResponseDto trySignInUser(SignInRequestDto signInRequest);
+}

--- a/src/main/java/com/flab/yousinsa/user/service/converter/SignInDtoConverter.java
+++ b/src/main/java/com/flab/yousinsa/user/service/converter/SignInDtoConverter.java
@@ -1,0 +1,18 @@
+package com.flab.yousinsa.user.service.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.flab.yousinsa.user.domain.dtos.response.SignInResponseDto;
+import com.flab.yousinsa.user.domain.entities.UserEntity;
+
+@Component
+public class SignInDtoConverter {
+	public SignInResponseDto convertUserToSignInUserResponse(UserEntity userEntity) {
+		return new SignInResponseDto(
+			userEntity.getId(),
+			userEntity.getUserName(),
+			userEntity.getUserEmail(),
+			userEntity.getUserRole()
+		);
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/service/exception/AuthException.java
+++ b/src/main/java/com/flab/yousinsa/user/service/exception/AuthException.java
@@ -1,0 +1,19 @@
+package com.flab.yousinsa.user.service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class AuthException extends RuntimeException {
+	public AuthException(String message) {
+		super(message);
+	}
+
+	public AuthException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AuthException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/service/exception/SignInFailException.java
+++ b/src/main/java/com/flab/yousinsa/user/service/exception/SignInFailException.java
@@ -1,0 +1,19 @@
+package com.flab.yousinsa.user.service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class SignInFailException extends RuntimeException {
+	public SignInFailException(String message) {
+		super(message);
+	}
+
+	public SignInFailException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SignInFailException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/service/exception/SignOutFailException.java
+++ b/src/main/java/com/flab/yousinsa/user/service/exception/SignOutFailException.java
@@ -1,0 +1,19 @@
+package com.flab.yousinsa.user.service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.RESET_CONTENT)
+public class SignOutFailException extends RuntimeException {
+	public SignOutFailException(String message) {
+		super(message);
+	}
+
+	public SignOutFailException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SignOutFailException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/service/impl/UserSignInServiceImpl.java
+++ b/src/main/java/com/flab/yousinsa/user/service/impl/UserSignInServiceImpl.java
@@ -1,0 +1,50 @@
+package com.flab.yousinsa.user.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import com.flab.yousinsa.user.domain.dtos.request.SignInRequestDto;
+import com.flab.yousinsa.user.domain.dtos.response.SignInResponseDto;
+import com.flab.yousinsa.user.domain.entities.UserEntity;
+import com.flab.yousinsa.user.repository.contract.UserRepository;
+import com.flab.yousinsa.user.service.PasswordEncoder;
+import com.flab.yousinsa.user.service.contract.UserSignInService;
+import com.flab.yousinsa.user.service.converter.SignInDtoConverter;
+import com.flab.yousinsa.user.service.exception.SignInFailException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@Slf4j
+public class UserSignInServiceImpl implements UserSignInService {
+
+	private final UserRepository userRepository;
+	private final SignInDtoConverter signInDtoConverter;
+	private final PasswordEncoder passwordEncoder;
+
+	public UserSignInServiceImpl(UserRepository userRepository, SignInDtoConverter signInDtoConverter,
+		PasswordEncoder passwordEncoder) {
+		this.userRepository = userRepository;
+		this.signInDtoConverter = signInDtoConverter;
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	@Override
+	public SignInResponseDto trySignInUser(SignInRequestDto signInRequest) {
+		Assert.notNull(signInRequest, "SignInRequestDto must be not null");
+
+		UserEntity findUser = userRepository.findByUserEmail(signInRequest.getUserEmail()).orElseThrow(
+			() -> new SignInFailException("request email is not found")
+		);
+
+		Boolean isMatched = passwordEncoder.isMatched(signInRequest.getUserPassword(), findUser.getUserPassword());
+		if (!isMatched) {
+			throw new SignInFailException("password is not valid with email");
+		}
+
+		return signInDtoConverter.convertUserToSignInUserResponse(findUser);
+	}
+
+}

--- a/src/main/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImpl.java
+++ b/src/main/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImpl.java
@@ -1,7 +1,5 @@
 package com.flab.yousinsa.user.service.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -15,17 +13,18 @@ import com.flab.yousinsa.user.service.contract.UserSignUpService;
 import com.flab.yousinsa.user.service.converter.SignUpDtoConverter;
 import com.flab.yousinsa.user.service.exception.SignUpFailException;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Service
 @Transactional
-public class UserService implements UserSignUpService {
-
-	private final Logger LOGGER = LoggerFactory.getLogger(UserService.class);
+@Slf4j
+public class UserSignUpServiceImpl implements UserSignUpService {
 
 	private final UserRepository userRepository;
 	private final SignUpDtoConverter signUpDtoConverter;
 	private final PasswordEncoder passwordEncoder;
 
-	public UserService(UserRepository userRepository, SignUpDtoConverter signUpDtoConverter,
+	public UserSignUpServiceImpl(UserRepository userRepository, SignUpDtoConverter signUpDtoConverter,
 		PasswordEncoder passwordEncoder) {
 		this.userRepository = userRepository;
 		this.signUpDtoConverter = signUpDtoConverter;
@@ -35,7 +34,7 @@ public class UserService implements UserSignUpService {
 	@Override
 	public SignUpResponseDto trySignUpUser(SignUpRequestDto signUpRequest) {
 		Assert.notNull(signUpRequest, "SignUpRequest must be not null");
-		validateSignUser(signUpRequest);
+		validateSignUpUser(signUpRequest);
 
 		String hashedPassword = passwordEncoder.hashPassword(signUpRequest.getUserPassword());
 
@@ -46,11 +45,12 @@ public class UserService implements UserSignUpService {
 		return signUpDtoConverter.convertUserToSignUpResponse(savedUser);
 	}
 
-	private void validateSignUser(SignUpRequestDto signUpRequest) {
+	private void validateSignUpUser(SignUpRequestDto signUpRequest) {
 		boolean isPresent = userRepository.findByUserEmail(signUpRequest.getUserEmail()).isPresent();
 		if (isPresent) {
-			LOGGER.info("validateSignUser :: " + signUpRequest.getUserEmail());
+			log.info("validateSignUser :: " + signUpRequest.getUserEmail());
 			throw new SignUpFailException("request email is already exists");
 		}
 	}
+
 }

--- a/src/test/java/com/flab/yousinsa/user/controller/api/UserControllerTest.java
+++ b/src/test/java/com/flab/yousinsa/user/controller/api/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.flab.yousinsa.user.controller.api;
 
 import static com.flab.yousinsa.ApiDocumentUtils.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -17,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -24,10 +26,16 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.yousinsa.annotation.UnitTest;
+import com.flab.yousinsa.user.config.AuthWebConfig;
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
+import com.flab.yousinsa.user.domain.dtos.request.SignInRequestDto;
 import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
+import com.flab.yousinsa.user.domain.dtos.response.SignInResponseDto;
 import com.flab.yousinsa.user.domain.dtos.response.SignUpResponseDto;
 import com.flab.yousinsa.user.domain.entities.UserEntity;
 import com.flab.yousinsa.user.domain.enums.UserRole;
+import com.flab.yousinsa.user.service.contract.UserSignInService;
 import com.flab.yousinsa.user.service.contract.UserSignUpService;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
@@ -45,19 +53,23 @@ class UserControllerTest {
 	@MockBean
 	private UserSignUpService userSignUpService;
 
-	private UserEntity user;
+	UserEntity user;
+	String rawPassword = "password";
+	@MockBean
+	private UserSignInService userSignInService;
 
 	@BeforeEach
 	public void setUp() {
 		user = new UserEntity("key", "rlfbd5142@gmail.com", "hashedPassword", UserRole.BUYER);
 	}
 
+	@UnitTest
 	@Test
 	@DisplayName("회원가입 API")
 	public void signUp() throws Exception {
 		// given
 		SignUpRequestDto signUpRequestDto = new SignUpRequestDto(user.getUserName(), user.getUserEmail(),
-			"password", user.getUserRole());
+			rawPassword, user.getUserRole());
 		SignUpResponseDto signUpResponseDto = new SignUpResponseDto(1L, user.getUserName(), user.getUserEmail(),
 			user.getUserRole());
 
@@ -66,7 +78,7 @@ class UserControllerTest {
 
 		// when
 		ResultActions result = mockMvc.perform(
-			post("/api/v1/users")
+			post("/api/v1/users/sign-up")
 				.content(objectMapper.writeValueAsString(signUpRequestDto))
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
@@ -94,5 +106,107 @@ class UserControllerTest {
 			);
 
 		then(userSignUpService).should().trySignUpUser(refEq(signUpRequestDto));
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 API")
+	public void signIn() throws Exception {
+		// given
+		SignInRequestDto signInRequestDto = new SignInRequestDto(user.getUserEmail(), rawPassword);
+		SignInResponseDto signInResponseDto = new SignInResponseDto(1L, user.getUserName(), user.getUserEmail(),
+			user.getUserRole());
+
+		MockHttpSession mockHttpSession = new MockHttpSession();
+
+		given(userSignInService.trySignInUser(any(SignInRequestDto.class)))
+			.willReturn(signInResponseDto);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/v1/users/sign-in").session(mockHttpSession)
+			.content(objectMapper.writeValueAsString(signInRequestDto))
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(content().string(objectMapper.writeValueAsString(signInResponseDto)))
+			.andDo(
+				document("user-signin",
+					getDocumentRequest(),
+					getDocumentResponse(),
+					requestFields(
+						fieldWithPath("userEmail").type(JsonFieldType.STRING).description("로그인 하고자 하는 유저 이메일"),
+						fieldWithPath("userPassword").type(JsonFieldType.STRING).description("로그인 하고자 하는 유저 비밀번호")
+					),
+					responseFields(
+						fieldWithPath("id").type(JsonFieldType.NUMBER).description("로그인된 유저 아이디(pk)"),
+						fieldWithPath("userName").type(JsonFieldType.STRING).description("로그인된 유저 이름"),
+						fieldWithPath("userEmail").type(JsonFieldType.STRING).description("로그인된 유저 이메일"),
+						fieldWithPath("userRole").type(JsonFieldType.STRING).description("로그인된 유저 역할")
+					)
+				)
+			);
+
+		AuthUser authUser = (AuthUser)mockHttpSession.getAttribute(AuthWebConfig.Session.AUTH_USER);
+		assertThat(authUser.getUserEmail()).isEqualTo(signInResponseDto.getUserEmail());
+		assertThat(authUser.getUserName()).isEqualTo(signInResponseDto.getUserName());
+		assertThat(authUser.getUserRole()).isEqualTo(signInResponseDto.getUserRole());
+
+		then(userSignInService).should().trySignInUser(refEq(signInRequestDto));
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그아웃 API")
+	public void signOut() throws Exception {
+		// given
+		MockHttpSession mockHttpSession = new MockHttpSession();
+		SignInResponseDto signInResponseDto = new SignInResponseDto(1L, user.getUserName(), user.getUserEmail(),
+			user.getUserRole());
+		mockHttpSession.setAttribute(AuthWebConfig.Session.AUTH_USER, signInResponseDto);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/users/sign-out").session(mockHttpSession));
+
+		// then
+		resultActions.andExpect(status().isResetContent())
+			.andDo(
+				document("user-signout",
+					getDocumentRequest(),
+					getDocumentResponse())
+			);
+
+		assertThatThrownBy(() -> mockHttpSession.getAttribute(AuthWebConfig.Session.AUTH_USER))
+			.isInstanceOf(IllegalStateException.class);
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("이미 로그아웃시 로그아웃 실패")
+	public void signOutFail() throws Exception {
+		// given
+		// NoSession
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/users/sign-out"));
+
+		// then
+		resultActions.andExpect(status().isUnauthorized());
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("회원가입, 로그인이 아닌 API에 대해서 Session이 없는 경우 인증되지 않음(401) 반환")
+	public void authRejectByAuthUserInterceptor() throws Exception {
+		// given
+		// NoSession
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/users/test"));
+
+		// then
+		resultActions.andExpect(status().isUnauthorized());
 	}
 }

--- a/src/test/java/com/flab/yousinsa/user/service/impl/UserSignInServiceImplTest.java
+++ b/src/test/java/com/flab/yousinsa/user/service/impl/UserSignInServiceImplTest.java
@@ -1,0 +1,113 @@
+package com.flab.yousinsa.user.service.impl;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flab.yousinsa.annotation.UnitTest;
+import com.flab.yousinsa.user.domain.dtos.request.SignInRequestDto;
+import com.flab.yousinsa.user.domain.dtos.response.SignInResponseDto;
+import com.flab.yousinsa.user.domain.entities.UserEntity;
+import com.flab.yousinsa.user.domain.enums.UserRole;
+import com.flab.yousinsa.user.repository.contract.UserRepository;
+import com.flab.yousinsa.user.service.PasswordEncoder;
+import com.flab.yousinsa.user.service.converter.SignInDtoConverter;
+import com.flab.yousinsa.user.service.exception.SignInFailException;
+
+@ExtendWith(MockitoExtension.class)
+class UserSignInServiceImplTest {
+
+	@Mock
+	UserRepository userRepository;
+
+	@Mock
+	SignInDtoConverter signInDtoConverter;
+
+	@Mock
+	PasswordEncoder passwordEncoder;
+
+	@InjectMocks
+	UserSignInServiceImpl userSignInService;
+
+	UserEntity user;
+	String password = "password";
+	String hashedPassword = "hashedPassword";
+	SignInResponseDto signInResponseDto;
+
+	@BeforeEach
+	public void setUp() {
+		user = new UserEntity("key", "rlfbd5142@gmail.com", hashedPassword, UserRole.BUYER);
+		signInResponseDto = new SignInResponseDto(1L, user.getUserName(), user.getUserEmail(), user.getUserRole());
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("가입한 적이 없는 유저가 로그인하는 경우")
+	public void testTrySignInUserIfNoUser() {
+		// given
+		String noExistUserEmail = "no-user@gmail.com";
+		given(userRepository.findByUserEmail(anyString())).willReturn(Optional.empty());
+		SignInRequestDto signInRequestDto = new SignInRequestDto(noExistUserEmail, password);
+
+		// when
+		Assertions.assertThatThrownBy(() -> {
+				SignInResponseDto signInResponseDto = userSignInService.trySignInUser(signInRequestDto);
+			})
+			.isInstanceOf(SignInFailException.class)
+			.hasMessageContaining("request email is not found");
+
+		then(userRepository).should().findByUserEmail(noExistUserEmail);
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("가입한 유저가 비밀번호를 잘못 입력하고 로그인하는 경우")
+	public void testTrySignInUserIfUserExistInvalidPassword() {
+		// given
+		SignInRequestDto signInRequestDto = new SignInRequestDto(user.getUserEmail(), password);
+		given(userRepository.findByUserEmail(anyString())).willReturn(Optional.of(user));
+		given(passwordEncoder.isMatched(anyString(), anyString())).willReturn(false);
+
+		// when
+		Assertions.assertThatThrownBy(() -> {
+				SignInResponseDto signInResponseDto = userSignInService.trySignInUser(signInRequestDto);
+			})
+			.isInstanceOf(SignInFailException.class)
+			.hasMessageContaining("password is not valid with email");
+
+		// then
+		then(userRepository).should().findByUserEmail(signInResponseDto.getUserEmail());
+		then(passwordEncoder).should().isMatched(eq(password), eq(hashedPassword));
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("가입한 유저가 비밀번호를 정상적으로 입력하고 로그인하는 경우")
+	public void testTrySignInUserIfUserExistValidPassword() {
+		//given
+		SignInRequestDto signInRequestDto = new SignInRequestDto(user.getUserEmail(), password);
+		given(userRepository.findByUserEmail(anyString())).willReturn(Optional.of(user));
+		given(signInDtoConverter.convertUserToSignInUserResponse(any(UserEntity.class))).willReturn(signInResponseDto);
+		given(passwordEncoder.isMatched(anyString(), anyString())).willReturn(true);
+
+		// when
+		SignInResponseDto signInResponseDto = userSignInService.trySignInUser(signInRequestDto);
+
+		// then
+		Assertions.assertThat(signInResponseDto.getUserName()).isEqualTo(user.getUserName());
+		Assertions.assertThat(signInResponseDto.getUserEmail()).isEqualTo(user.getUserEmail());
+
+		then(userRepository).should().findByUserEmail(eq(signInRequestDto.getUserEmail()));
+		then(signInDtoConverter).should().convertUserToSignInUserResponse(eq(user));
+		then(passwordEncoder).should().isMatched(eq(password), eq(hashedPassword));
+	}
+}

--- a/src/test/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImplTest.java
+++ b/src/test/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImplTest.java
@@ -25,7 +25,7 @@ import com.flab.yousinsa.user.service.converter.SignUpDtoConverter;
 import com.flab.yousinsa.user.service.exception.SignUpFailException;
 
 @ExtendWith(MockitoExtension.class)
-class UserServiceTest {
+class UserSignUpServiceImplTest {
 
 	@Mock
 	UserRepository userRepository;
@@ -37,7 +37,7 @@ class UserServiceTest {
 	PasswordEncoder passwordEncoder;
 
 	@InjectMocks
-	UserService userService;
+	UserSignUpServiceImpl userSignUpServiceImpl;
 
 	UserEntity user;
 
@@ -65,7 +65,7 @@ class UserServiceTest {
 		given(signUpDtoConverter.convertUserToSignUpResponse(any(UserEntity.class))).willReturn(signUpResponseDto);
 
 		// when
-		SignUpResponseDto resultResponse = userService.trySignUpUser(signUpRequestDto);
+		SignUpResponseDto resultResponse = userSignUpServiceImpl.trySignUpUser(signUpRequestDto);
 
 		// then
 		then(userRepository).should().save(user);
@@ -89,7 +89,7 @@ class UserServiceTest {
 
 		// when, then
 		Assertions.assertThrows(SignUpFailException.class, () -> {
-			SignUpResponseDto savedUser = userService.trySignUpUser(signUpRequestDto);
+			SignUpResponseDto savedUser = userSignUpServiceImpl.trySignUpUser(signUpRequestDto);
 		});
 
 		then(userRepository).should().findByUserEmail(signUpRequestDto.getUserEmail());


### PR DESCRIPTION
## 개요

- [x] Feature
- [ ] Bug Fix
- [ ] Setup

## 작업 사항

- 로그인/로그아웃 API를 구현했습니다.

- 세션 클러스터링은 적용하지 않았습니다.
  - v2 : 리팩토링(구조 개선)에서 적용할 예정입니다.
    - Spring-Session-Redis, Spring-Session-JDBC 등의 모듈 중에 선정하여 적용

- 로그인 되었는지 확인 하는 부분을 `Interceptor`에서 처리하도록 진행했습니다.
  - 해당 기능은 대한 고민은 Filter, Interceptor, AOP  3가지 기술 중 어떤 것을 적용할지였습니다.
  - 1차적으로 Version1 에서 진행하는 부분은 interceptor를 선정했습니다. 
     - 이유는 다음과 같습니다.
     - 1. Filter는 비즈니스 도메인과 무관하게 설계하는 Convention이 있기 때문에 제외했습니다.
     - 2. AOP는 흩어져 있는 공통 관심사를 다루기 위해 사용하는 기술이기 때문에 사용자(User)라는 도메인을 모르게 설계하는게 맞다고 판단했습니다.

#8 #9 

## 기타

- [ ] Reviewers
- [x] Assignees
- [ ] Labels
- [ ] Projects
- [ ] Milestone
- [ ] Development (Issue Link)
