### PR TITLE
[#11] 회원탈퇴 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -51,10 +51,16 @@ YOUSINSA REST API에서 사용하는 HTTP Method는 REST 방식으로 작성되�
 | 새 리소스를 성공적으로 생성함. 응답의 `Location` 헤더에 해당 리소스의 URI가 담겨있다.
 
 | `204 No Content`
-| 기존 리소스를 성공적으로 수정함.
+| 기존 리소스의 제거를 성공적으로 수정함.
+
+| `205 Reset Content`
+| 기존 리소스의 제거를 성공적으로 수정함.
 
 | `400 Bad Request`
 | 잘못된 요청을 보낸 경우. 응답 본문에 더 오류에 대한 정보가 담겨있다.
+
+| `401 Unauthorized`
+| 인증이 필요한 리소스
 
 | `404 Not Found`
 | 요청한 리소스가 없음.
@@ -65,4 +71,16 @@ YOUSINSA REST API에서 사용하는 HTTP Method는 REST 방식으로 작성되�
 === SignUp
 
 operation::user-signup[snippets='curl-request,http-request,http-response,request-body,request-fields,response-body,response-fields']
+
+=== Withdraw
+
+operation::user-withdraw[snippets='curl-request,http-request,http-response,path-parameters']
+
+=== SignIn
+
+operation::user-signin[snippets='curl-request,http-request,http-response,request-body,request-fields,response-body,response-fields']
+
+=== SignOut
+
+operation::user-signout[snippets='curl-request,http-request,http-response']
 

--- a/src/main/java/com/flab/yousinsa/user/config/AuthWebConfig.java
+++ b/src/main/java/com/flab/yousinsa/user/config/AuthWebConfig.java
@@ -1,0 +1,31 @@
+package com.flab.yousinsa.user.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.flab.yousinsa.user.controller.component.AuthUserHandlerMethodArgumentResolver;
+import com.flab.yousinsa.user.controller.interceptor.AuthUserInterceptor;
+
+@Configuration
+public class AuthWebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new AuthUserInterceptor())
+			.addPathPatterns("/**")
+			.excludePathPatterns("/**/users/sign-up", "/**/users/sign-in");
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new AuthUserHandlerMethodArgumentResolver());
+	}
+
+	public static class Session {
+		public static final String AUTH_USER = "AuthUser";
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/controller/annotation/SessionAuth.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/annotation/SessionAuth.java
@@ -1,0 +1,11 @@
+package com.flab.yousinsa.user.controller.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SessionAuth {
+}

--- a/src/main/java/com/flab/yousinsa/user/controller/api/UserController.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/api/UserController.java
@@ -3,10 +3,15 @@ package com.flab.yousinsa.user.controller.api;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.flab.yousinsa.user.controller.annotation.SessionAuth;
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
+import com.flab.yousinsa.user.domain.dtos.request.SignInRequestDto;
 import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
 import com.flab.yousinsa.user.domain.dtos.response.SignUpResponseDto;
 import com.flab.yousinsa.user.service.contract.UserSignUpService;
@@ -25,5 +30,46 @@ public class UserController {
 	public ResponseEntity<SignUpResponseDto> signUpUser(@RequestBody SignUpRequestDto signUpRequest) {
 		SignUpResponseDto signUpResponse = userService.trySignUpUser(signUpRequest);
 		return ResponseEntity.ok(signUpResponse);
+	}
+
+	@PostMapping("api/v1/users/sign-in")
+	public ResponseEntity<SignInResponseDto> signInUser(@Valid @RequestBody SignInRequestDto signInRequestDto,
+		HttpSession httpSession) {
+		SignInResponseDto signInResponseDto = userSignInService.trySignInUser(signInRequestDto);
+		AuthUser authUser = new AuthUser(
+			signInResponseDto.getId(),
+			signInResponseDto.getUserName(),
+			signInResponseDto.getUserEmail(),
+			signInResponseDto.getUserRole()
+		);
+		httpSession.setAttribute(AUTH_USER, authUser);
+
+		return ResponseEntity.ok(signInResponseDto);
+	}
+
+	@DeleteMapping("api/v1/users/sign-out")
+	public ResponseEntity<Void> signOutUser(HttpSession httpSession) {
+		try {
+			httpSession.invalidate();
+		} catch (IllegalStateException e) {
+			if (log.isErrorEnabled()) {
+				log.error("User already signed out", e);
+			}
+
+			throw new SignOutFailException("User already signed out", e);
+		}
+
+		return ResponseEntity.status(HttpStatus.RESET_CONTENT).build();
+	}
+
+	@SessionAuth
+	@DeleteMapping("api/v1/users/{userId}")
+	public ResponseEntity<Void> withDrawUser(AuthUser user, @PathVariable("userId") Long userId,
+		HttpSession httpSession) {
+		userSignUpService.tryWithdrawUser(user, userId);
+
+		httpSession.invalidate();
+
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/com/flab/yousinsa/user/controller/component/AuthUserHandlerMethodArgumentResolver.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/component/AuthUserHandlerMethodArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.flab.yousinsa.user.controller.component;
+
+import static com.flab.yousinsa.user.config.AuthWebConfig.Session.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.flab.yousinsa.user.controller.annotation.SessionAuth;
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
+
+public class AuthUserHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		boolean hasSessionAuthAnnotation = parameter.hasMethodAnnotation(SessionAuth.class);
+		boolean hasAuthUserType = AuthUser.class.isAssignableFrom(parameter.getParameterType());
+		return hasSessionAuthAnnotation && hasAuthUserType;
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)webRequest.getNativeRequest();
+		HttpSession session = httpServletRequest.getSession(false);
+		if (session == null) {
+			return null;
+		}
+
+		return session.getAttribute(AUTH_USER);
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/service/contract/UserSignUpService.java
+++ b/src/main/java/com/flab/yousinsa/user/service/contract/UserSignUpService.java
@@ -1,8 +1,11 @@
 package com.flab.yousinsa.user.service.contract;
 
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
 import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
 import com.flab.yousinsa.user.domain.dtos.response.SignUpResponseDto;
 
 public interface UserSignUpService {
 	SignUpResponseDto trySignUpUser(SignUpRequestDto signUpRequest);
+
+	void tryWithdrawUser(AuthUser user, Long withDrawUserId);
 }

--- a/src/main/java/com/flab/yousinsa/user/service/exception/WithdrawFailException.java
+++ b/src/main/java/com/flab/yousinsa/user/service/exception/WithdrawFailException.java
@@ -1,0 +1,19 @@
+package com.flab.yousinsa.user.service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class WithdrawFailException extends RuntimeException{
+	public WithdrawFailException(String message) {
+		super(message);
+	}
+
+	public WithdrawFailException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public WithdrawFailException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImpl.java
+++ b/src/main/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImpl.java
@@ -1,0 +1,77 @@
+package com.flab.yousinsa.user.service.impl;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
+import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
+import com.flab.yousinsa.user.domain.dtos.response.SignUpResponseDto;
+import com.flab.yousinsa.user.domain.entities.UserEntity;
+import com.flab.yousinsa.user.repository.contract.UserRepository;
+import com.flab.yousinsa.user.service.PasswordEncoder;
+import com.flab.yousinsa.user.service.contract.UserSignUpService;
+import com.flab.yousinsa.user.service.converter.SignUpDtoConverter;
+import com.flab.yousinsa.user.service.exception.AuthException;
+import com.flab.yousinsa.user.service.exception.SignUpFailException;
+import com.flab.yousinsa.user.service.exception.WithdrawFailException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@Slf4j
+public class UserSignUpServiceImpl implements UserSignUpService {
+
+	private final UserRepository userRepository;
+	private final SignUpDtoConverter signUpDtoConverter;
+	private final PasswordEncoder passwordEncoder;
+
+	public UserSignUpServiceImpl(UserRepository userRepository, SignUpDtoConverter signUpDtoConverter,
+		PasswordEncoder passwordEncoder) {
+		this.userRepository = userRepository;
+		this.signUpDtoConverter = signUpDtoConverter;
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	@Override
+	public SignUpResponseDto trySignUpUser(SignUpRequestDto signUpRequest) {
+		Assert.notNull(signUpRequest, "SignUpRequest must be not null");
+		validateSignUpUser(signUpRequest);
+
+		String hashedPassword = passwordEncoder.hashPassword(signUpRequest.getUserPassword());
+
+		UserEntity newUser = signUpDtoConverter.convertSignUpRequestToUser(signUpRequest, hashedPassword);
+
+		UserEntity savedUser = userRepository.save(newUser);
+
+		return signUpDtoConverter.convertUserToSignUpResponse(savedUser);
+	}
+
+	@Override
+	public void tryWithdrawUser(AuthUser user, Long withdrawUserId) {
+		Assert.notNull(user, "To withdraw user, user must be logined");
+		Assert.notNull(withdrawUserId, "To withdraw user, valid withdrawUserId must given");
+
+		if (!Objects.equals(user.getId(), withdrawUserId)) {
+			throw new AuthException("Withdrawn userId must be equal to logined UserId");
+		}
+
+		UserEntity userEntity = userRepository.findById(withdrawUserId).orElseThrow(
+			() -> new WithdrawFailException("Withdraw user id does not exist")
+		);
+
+		userRepository.delete(userEntity);
+	}
+
+	private void validateSignUpUser(SignUpRequestDto signUpRequest) {
+		boolean isPresent = userRepository.findByUserEmail(signUpRequest.getUserEmail()).isPresent();
+		if (isPresent) {
+			log.info("validateSignUser :: " + signUpRequest.getUserEmail());
+			throw new SignUpFailException("request email is already exists");
+		}
+	}
+
+}

--- a/src/test/java/com/flab/yousinsa/user/controller/api/UserControllerTest.java
+++ b/src/test/java/com/flab/yousinsa/user/controller/api/UserControllerTest.java
@@ -4,6 +4,8 @@ import static com.flab.yousinsa.ApiDocumentUtils.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -18,6 +20,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -53,7 +56,7 @@ class UserControllerTest {
 	}
 
 	@Test
-	@DisplayName("회원가입 API")
+	@DisplayName("회원가입 API Doc")
 	public void signUp() throws Exception {
 		// given
 		SignUpRequestDto signUpRequestDto = new SignUpRequestDto(user.getUserName(), user.getUserEmail(),
@@ -94,5 +97,145 @@ class UserControllerTest {
 			);
 
 		then(userSignUpService).should().trySignUpUser(refEq(signUpRequestDto));
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 API Doc")
+	public void signIn() throws Exception {
+		// given
+		SignInRequestDto signInRequestDto = new SignInRequestDto(user.getUserEmail(), rawPassword);
+		SignInResponseDto signInResponseDto = new SignInResponseDto(1L, user.getUserName(), user.getUserEmail(),
+			user.getUserRole());
+
+		MockHttpSession mockHttpSession = new MockHttpSession();
+
+		given(userSignInService.trySignInUser(any(SignInRequestDto.class)))
+			.willReturn(signInResponseDto);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/v1/users/sign-in").session(mockHttpSession)
+			.content(objectMapper.writeValueAsString(signInRequestDto))
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(content().string(objectMapper.writeValueAsString(signInResponseDto)))
+			.andDo(
+				document("user-signin",
+					getDocumentRequest(),
+					getDocumentResponse(),
+					requestFields(
+						fieldWithPath("userEmail").type(JsonFieldType.STRING).description("로그인 하고자 하는 유저 이메일"),
+						fieldWithPath("userPassword").type(JsonFieldType.STRING).description("로그인 하고자 하는 유저 비밀번호")
+					),
+					responseFields(
+						fieldWithPath("id").type(JsonFieldType.NUMBER).description("로그인된 유저 아이디(pk)"),
+						fieldWithPath("userName").type(JsonFieldType.STRING).description("로그인된 유저 이름"),
+						fieldWithPath("userEmail").type(JsonFieldType.STRING).description("로그인된 유저 이메일"),
+						fieldWithPath("userRole").type(JsonFieldType.STRING).description("로그인된 유저 역할")
+					)
+				)
+			);
+
+		AuthUser authUser = (AuthUser)mockHttpSession.getAttribute(AuthWebConfig.Session.AUTH_USER);
+		assertThat(authUser.getUserEmail()).isEqualTo(signInResponseDto.getUserEmail());
+		assertThat(authUser.getUserName()).isEqualTo(signInResponseDto.getUserName());
+		assertThat(authUser.getUserRole()).isEqualTo(signInResponseDto.getUserRole());
+
+		then(userSignInService).should().trySignInUser(refEq(signInRequestDto));
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그아웃 API Doc")
+	public void signOut() throws Exception {
+		// given
+		MockHttpSession mockHttpSession = new MockHttpSession();
+		SignInResponseDto signInResponseDto = new SignInResponseDto(1L, user.getUserName(), user.getUserEmail(),
+			user.getUserRole());
+		mockHttpSession.setAttribute(AuthWebConfig.Session.AUTH_USER, signInResponseDto);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/users/sign-out").session(mockHttpSession));
+
+		// then
+		resultActions.andExpect(status().isResetContent())
+			.andDo(
+				document("user-signout",
+					getDocumentRequest(),
+					getDocumentResponse())
+			);
+
+		assertThatThrownBy(() -> mockHttpSession.getAttribute(AuthWebConfig.Session.AUTH_USER))
+			.isInstanceOf(IllegalStateException.class);
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("회원탈퇴 API Doc")
+	public void withDraw() throws Exception {
+		// given
+		MockHttpSession mockHttpSession = new MockHttpSession();
+		Long deleteTargetUserId = 1L;
+		AuthUser authUser = new AuthUser(deleteTargetUserId, user.getUserName(), user.getUserEmail(),
+			user.getUserRole());
+		mockHttpSession.setAttribute(AuthWebConfig.Session.AUTH_USER, authUser);
+		willDoNothing().given(userSignUpService).tryWithdrawUser(any(AuthUser.class), anyLong());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(
+			RestDocumentationRequestBuilders.delete("/api/v1/users/{userId}", deleteTargetUserId).session(
+				mockHttpSession));
+
+		// then
+		resultActions.andExpect(status().isNoContent())
+			.andDo(
+				document("user-withdraw",
+					getDocumentRequest(),
+					getDocumentResponse(),
+					pathParameters(
+						parameterWithName("userId").description("userId of withdraw requested user")
+							.attributes(key("type").value(LONG))
+					)
+				)
+			);
+
+		then(userSignUpService).should().tryWithdrawUser(refEq(authUser), refEq(deleteTargetUserId));
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("이미 로그아웃시 로그아웃 실패")
+	public void signOutFail() throws Exception {
+		// given
+		// NoSession
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/users/sign-out"));
+
+		// then
+		resultActions.andExpect(status().isUnauthorized());
+	}
+
+	/**
+	 * 해당 되는 URL 패턴의 API가 있을 경우 Method가 다르면 401이 아니라 Method_Not_Allowed(405)가 반환됨
+	 * 따라서 이 테스트가 변동 사항이 없도록 만들 예정이 없는 URL로 테스트를 진행
+	 * @throws Exception
+	 */
+	@UnitTest
+	@Test
+	@DisplayName("회원가입, 로그인이 아닌 API에 대해서 Session이 없는 경우 인증되지 않음(401) 반환")
+	public void authRejectByAuthUserInterceptor() throws Exception {
+		// given
+		// NoSession
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/test"));
+
+		// then
+		resultActions.andExpect(status().isUnauthorized());
 	}
 }

--- a/src/test/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImplTest.java
+++ b/src/test/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImplTest.java
@@ -1,0 +1,161 @@
+package com.flab.yousinsa.user.service.impl;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flab.yousinsa.annotation.UnitTest;
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
+import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
+import com.flab.yousinsa.user.domain.dtos.response.SignUpResponseDto;
+import com.flab.yousinsa.user.domain.entities.UserEntity;
+import com.flab.yousinsa.user.domain.enums.UserRole;
+import com.flab.yousinsa.user.repository.contract.UserRepository;
+import com.flab.yousinsa.user.service.PasswordEncoder;
+import com.flab.yousinsa.user.service.converter.SignUpDtoConverter;
+import com.flab.yousinsa.user.service.exception.AuthException;
+import com.flab.yousinsa.user.service.exception.SignUpFailException;
+
+@ExtendWith(MockitoExtension.class)
+class UserSignUpServiceImplTest {
+
+	@Mock
+	UserRepository userRepository;
+
+	@Mock
+	SignUpDtoConverter signUpDtoConverter;
+
+	@Mock
+	PasswordEncoder passwordEncoder;
+
+	@InjectMocks
+	UserSignUpServiceImpl userSignUpServiceImpl;
+
+	UserEntity user;
+
+	final String HashedPassword = "hashedPassword";
+
+	@BeforeEach
+	public void setUp() {
+		user = new UserEntity("key", "rlfbd5142@gmail.com", "hashedPassword", UserRole.BUYER);
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("같은 이메일을 가진 유저가 없어 정상적으로 회원가입 되는 경우")
+	public void signUpNoUserEmailTest() {
+		// given
+		SignUpRequestDto signUpRequestDto = new SignUpRequestDto(user.getUserName(), user.getUserEmail(),
+			"password", user.getUserRole());
+		SignUpResponseDto signUpResponseDto = new SignUpResponseDto(1L, user.getUserName(), user.getUserEmail(),
+			user.getUserRole());
+
+		given(userRepository.save(any(UserEntity.class))).willReturn(user);
+		given(passwordEncoder.hashPassword(signUpRequestDto.getUserPassword())).willReturn(HashedPassword);
+		given(signUpDtoConverter.convertSignUpRequestToUser(any(SignUpRequestDto.class), eq(HashedPassword)))
+			.willReturn(user);
+		given(signUpDtoConverter.convertUserToSignUpResponse(any(UserEntity.class))).willReturn(signUpResponseDto);
+
+		// when
+		SignUpResponseDto resultResponse = userSignUpServiceImpl.trySignUpUser(signUpRequestDto);
+
+		// then
+		then(userRepository).should().save(user);
+		then(passwordEncoder).should().hashPassword(signUpRequestDto.getUserPassword());
+		then(signUpDtoConverter).should().convertSignUpRequestToUser(signUpRequestDto, HashedPassword);
+		then(signUpDtoConverter).should().convertUserToSignUpResponse(user);
+
+		assertThat(resultResponse.getUserName()).isEqualTo(signUpResponseDto.getUserName());
+		assertThat(resultResponse.getUserEmail()).isEqualTo(signUpResponseDto.getUserEmail());
+		assertThat(resultResponse.getUserRole()).isEqualTo(signUpResponseDto.getUserRole());
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("같은 이메일을 가진 유저가 있어 회원가입이 안되는 경우")
+	public void signUpSameEmailUserExistTest() {
+		// given
+		SignUpRequestDto signUpRequestDto = new SignUpRequestDto(user.getUserName(), user.getUserEmail(),
+			"password", user.getUserRole());
+		given(userRepository.findByUserEmail(any(String.class))).willReturn(Optional.of(user));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> {
+				SignUpResponseDto savedUser = userSignUpServiceImpl.trySignUpUser(signUpRequestDto);
+			}).isInstanceOf(SignUpFailException.class)
+			.hasMessageContaining("request email is already exists");
+
+		then(userRepository).should().findByUserEmail(signUpRequestDto.getUserEmail());
+		then(userRepository).should(never()).save(user);
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 하지 않은 상태로 회원 탈퇴 시도")
+	public void withDrawUserIfNoLogin() {
+		long withDrawUserId = 1L;
+		Assertions.assertThatThrownBy(
+				() -> userSignUpServiceImpl.tryWithdrawUser(null, withDrawUserId)
+			).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("To withdraw user, user must be logined");
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 한 상태로 유효하지 않은 userId 시도")
+	public void withDrawUserIfLoginInvalidWithdrawUserId() {
+		// given
+		AuthUser authUser = new AuthUser(2L, "mockName", "mockEmail@gmail.com", UserRole.BUYER);
+		Long withDrawUserId = null;
+
+		Assertions.assertThatThrownBy(
+				() -> userSignUpServiceImpl.tryWithdrawUser(authUser, withDrawUserId)
+			).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("To withdraw user, valid withdrawUserId must given");
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 한 상태로 해당 유저가 아닌 회원 탈퇴 시도")
+	public void withDrawUserIfLoginButDifferentUserId() {
+		// given
+		AuthUser authUser = new AuthUser(2L, "mockName", "mockEmail@gmail.com", UserRole.BUYER);
+
+		// when
+		long withDrawUserId = 1L;
+		Assertions.assertThatThrownBy(
+				() -> userSignUpServiceImpl.tryWithdrawUser(authUser, withDrawUserId)
+			).isInstanceOf(AuthException.class)
+			.hasMessageContaining("Withdrawn userId must be equal to logined UserId");
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 한 상태로 해당 유저 회원 탈퇴 시도")
+	public void withDrawUserIfLoginButSameUserId() {
+		// given
+		long withDrawUserId = 1L;
+
+		Optional<UserEntity> userEntityOptional = Optional.of(user);
+		given(userRepository.findById(anyLong())).willReturn(userEntityOptional);
+		willDoNothing().given(userRepository).delete(any(UserEntity.class));
+		AuthUser authUser = new AuthUser(withDrawUserId, user.getUserName(), user.getUserEmail(), UserRole.BUYER);
+
+		// when
+		userSignUpServiceImpl.tryWithdrawUser(authUser, withDrawUserId);
+
+		then(userRepository).should().findById(withDrawUserId);
+		then(userRepository).should().delete(eq(user));
+	}
+
+}


### PR DESCRIPTION
## 개요

- [x] Feature
- [ ] Bug Fix
- [ ] Setup

## 작업 사항

- 회원 탈퇴 API를 구현했습니다.
  - 회원 탈퇴의 경우 현재 로그인 한 User가 자신에 대해 회원 탈퇴를 요청한 경우에만 진행하도록 설계했습니다.
  - 따라서, Login 한 뒤 Session이 생성되는 부분이 필요합니다(PR #C10이 먼저 병합 필요, 현재 PR cherry pick 이용) 

- Session에 있는 회원의 정보의 경우 `ArgumentResolver`를 활용해서 Controller 에서 받아올 수 있도록 진행했습니다.
  - 회원 탈퇴 후에 로그아웃도 진행시켰습니다.(Controller의 다른 Handler를 호출하는 것은 회원탈퇴와 로그아웃 기능이 강하게 결합하는 부분에서 사용하지 않고 Session을 회원탈퇴 API에서 만료시키는 방향으로 구현했습니다.)

#7 

## 기타

- [ ] Reviewers
- [x] Assignees
- [ ] Labels
- [ ] Projects
- [ ] Milestone
- [ ] Development (Issue Link)
