### PR TITLE
[#11] 회원탈퇴 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -51,13 +51,16 @@ YOUSINSA REST API에서 사용하는 HTTP Method는 REST 방식으로 작성되�
 | 새 리소스를 성공적으로 생성함. 응답의 `Location` 헤더에 해당 리소스의 URI가 담겨있다.
 
 | `204 No Content`
-| 기존 리소스를 성공적으로 수정함.
+| 기존 리소스의 제거를 성공적으로 수정함.
 
 | `205 Reset Content`
-| 컨텐츠의 갱신이 필요함.
+| 기존 리소스의 제거를 성공적으로 수정함.
 
 | `400 Bad Request`
 | 잘못된 요청을 보낸 경우. 응답 본문에 더 오류에 대한 정보가 담겨있다.
+
+| `401 Unauthorized`
+| 인증이 필요한 리소스
 
 | `404 Not Found`
 | 요청한 리소스가 없음.
@@ -69,6 +72,10 @@ YOUSINSA REST API에서 사용하는 HTTP Method는 REST 방식으로 작성되�
 
 operation::user-signup[snippets='curl-request,http-request,http-response,request-body,request-fields,response-body,response-fields']
 
+=== Withdraw
+
+operation::user-withdraw[snippets='curl-request,http-request,http-response,path-parameters']
+
 === SignIn
 
 operation::user-signin[snippets='curl-request,http-request,http-response,request-body,request-fields,response-body,response-fields']
@@ -76,3 +83,4 @@ operation::user-signin[snippets='curl-request,http-request,http-response,request
 === SignOut
 
 operation::user-signout[snippets='curl-request,http-request,http-response']
+

--- a/src/main/java/com/flab/yousinsa/user/config/AuthWebConfig.java
+++ b/src/main/java/com/flab/yousinsa/user/config/AuthWebConfig.java
@@ -1,9 +1,13 @@
 package com.flab.yousinsa.user.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.flab.yousinsa.user.controller.component.AuthUserHandlerMethodArgumentResolver;
 import com.flab.yousinsa.user.controller.interceptor.AuthUserInterceptor;
 
 @Configuration
@@ -14,6 +18,11 @@ public class AuthWebConfig implements WebMvcConfigurer {
 		registry.addInterceptor(new AuthUserInterceptor())
 			.addPathPatterns("/**")
 			.excludePathPatterns("/**/users/sign-up", "/**/users/sign-in");
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new AuthUserHandlerMethodArgumentResolver());
 	}
 
 	public static class Session {

--- a/src/main/java/com/flab/yousinsa/user/controller/annotation/SessionAuth.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/annotation/SessionAuth.java
@@ -1,0 +1,11 @@
+package com.flab.yousinsa.user.controller.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SessionAuth {
+}

--- a/src/main/java/com/flab/yousinsa/user/controller/api/UserController.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/api/UserController.java
@@ -8,10 +8,12 @@ import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.flab.yousinsa.user.controller.annotation.SessionAuth;
 import com.flab.yousinsa.user.domain.dtos.AuthUser;
 import com.flab.yousinsa.user.domain.dtos.request.SignInRequestDto;
 import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
@@ -69,5 +71,16 @@ public class UserController {
 		}
 
 		return ResponseEntity.status(HttpStatus.RESET_CONTENT).build();
+	}
+
+	@SessionAuth
+	@DeleteMapping("api/v1/users/{userId}")
+	public ResponseEntity<Void> withDrawUser(AuthUser user, @PathVariable("userId") Long userId,
+		HttpSession httpSession) {
+		userSignUpService.tryWithdrawUser(user, userId);
+
+		httpSession.invalidate();
+
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/com/flab/yousinsa/user/controller/component/AuthUserHandlerMethodArgumentResolver.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/component/AuthUserHandlerMethodArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.flab.yousinsa.user.controller.component;
+
+import static com.flab.yousinsa.user.config.AuthWebConfig.Session.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.flab.yousinsa.user.controller.annotation.SessionAuth;
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
+
+public class AuthUserHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		boolean hasSessionAuthAnnotation = parameter.hasMethodAnnotation(SessionAuth.class);
+		boolean hasAuthUserType = AuthUser.class.isAssignableFrom(parameter.getParameterType());
+		return hasSessionAuthAnnotation && hasAuthUserType;
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)webRequest.getNativeRequest();
+		HttpSession session = httpServletRequest.getSession(false);
+		if (session == null) {
+			return null;
+		}
+
+		return session.getAttribute(AUTH_USER);
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/service/contract/UserSignUpService.java
+++ b/src/main/java/com/flab/yousinsa/user/service/contract/UserSignUpService.java
@@ -1,8 +1,11 @@
 package com.flab.yousinsa.user.service.contract;
 
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
 import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
 import com.flab.yousinsa.user.domain.dtos.response.SignUpResponseDto;
 
 public interface UserSignUpService {
 	SignUpResponseDto trySignUpUser(SignUpRequestDto signUpRequest);
+
+	void tryWithdrawUser(AuthUser user, Long withDrawUserId);
 }

--- a/src/main/java/com/flab/yousinsa/user/service/exception/WithdrawFailException.java
+++ b/src/main/java/com/flab/yousinsa/user/service/exception/WithdrawFailException.java
@@ -1,0 +1,19 @@
+package com.flab.yousinsa.user.service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class WithdrawFailException extends RuntimeException{
+	public WithdrawFailException(String message) {
+		super(message);
+	}
+
+	public WithdrawFailException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public WithdrawFailException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/test/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImplTest.java
+++ b/src/test/java/com/flab/yousinsa/user/service/impl/UserSignUpServiceImplTest.java
@@ -5,7 +5,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.flab.yousinsa.annotation.UnitTest;
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
 import com.flab.yousinsa.user.domain.dtos.request.SignUpRequestDto;
 import com.flab.yousinsa.user.domain.dtos.response.SignUpResponseDto;
 import com.flab.yousinsa.user.domain.entities.UserEntity;
@@ -22,6 +23,7 @@ import com.flab.yousinsa.user.domain.enums.UserRole;
 import com.flab.yousinsa.user.repository.contract.UserRepository;
 import com.flab.yousinsa.user.service.PasswordEncoder;
 import com.flab.yousinsa.user.service.converter.SignUpDtoConverter;
+import com.flab.yousinsa.user.service.exception.AuthException;
 import com.flab.yousinsa.user.service.exception.SignUpFailException;
 
 @ExtendWith(MockitoExtension.class)
@@ -88,11 +90,72 @@ class UserSignUpServiceImplTest {
 		given(userRepository.findByUserEmail(any(String.class))).willReturn(Optional.of(user));
 
 		// when, then
-		Assertions.assertThrows(SignUpFailException.class, () -> {
-			SignUpResponseDto savedUser = userSignUpServiceImpl.trySignUpUser(signUpRequestDto);
-		});
+		Assertions.assertThatThrownBy(() -> {
+				SignUpResponseDto savedUser = userSignUpServiceImpl.trySignUpUser(signUpRequestDto);
+			}).isInstanceOf(SignUpFailException.class)
+			.hasMessageContaining("request email is already exists");
 
 		then(userRepository).should().findByUserEmail(signUpRequestDto.getUserEmail());
 		then(userRepository).should(never()).save(user);
 	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 하지 않은 상태로 회원 탈퇴 시도")
+	public void withDrawUserIfNoLogin() {
+		long withDrawUserId = 1L;
+		Assertions.assertThatThrownBy(
+				() -> userSignUpServiceImpl.tryWithdrawUser(null, withDrawUserId)
+			).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("To withdraw user, user must be logined");
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 한 상태로 유효하지 않은 userId 시도")
+	public void withDrawUserIfLoginInvalidWithdrawUserId() {
+		// given
+		AuthUser authUser = new AuthUser(2L, "mockName", "mockEmail@gmail.com", UserRole.BUYER);
+		Long withDrawUserId = null;
+
+		Assertions.assertThatThrownBy(
+				() -> userSignUpServiceImpl.tryWithdrawUser(authUser, withDrawUserId)
+			).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("To withdraw user, valid withdrawUserId must given");
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 한 상태로 해당 유저가 아닌 회원 탈퇴 시도")
+	public void withDrawUserIfLoginButDifferentUserId() {
+		// given
+		AuthUser authUser = new AuthUser(2L, "mockName", "mockEmail@gmail.com", UserRole.BUYER);
+
+		// when
+		long withDrawUserId = 1L;
+		Assertions.assertThatThrownBy(
+				() -> userSignUpServiceImpl.tryWithdrawUser(authUser, withDrawUserId)
+			).isInstanceOf(AuthException.class)
+			.hasMessageContaining("Withdrawn userId must be equal to logined UserId");
+	}
+
+	@UnitTest
+	@Test
+	@DisplayName("로그인 한 상태로 해당 유저 회원 탈퇴 시도")
+	public void withDrawUserIfLoginButSameUserId() {
+		// given
+		long withDrawUserId = 1L;
+
+		Optional<UserEntity> userEntityOptional = Optional.of(user);
+		given(userRepository.findById(anyLong())).willReturn(userEntityOptional);
+		willDoNothing().given(userRepository).delete(any(UserEntity.class));
+		AuthUser authUser = new AuthUser(withDrawUserId, user.getUserName(), user.getUserEmail(), UserRole.BUYER);
+
+		// when
+		userSignUpServiceImpl.tryWithdrawUser(authUser, withDrawUserId);
+
+		then(userRepository).should().findById(withDrawUserId);
+		then(userRepository).should().delete(eq(user));
+	}
+
 }


### PR DESCRIPTION
## 개요

- [x] Feature
- [ ] Bug Fix
- [ ] Setup

## 작업 사항

- 회원 탈퇴 API를 구현했습니다.

- ArgumentResolver를 통해 Session에 있는 로그인된 User 정보를 갖고 올 수 있도록 구현했습니다.

- 해당 PR의 경우 Develop을 Login Branch로 Rebase하여 작성했습니다.

## 기타

- [ ] Reviewers
- [x] Assignees
- [ ] Labels
- [ ] Projects
- [ ] Milestone
- [ ] Development (Issue Link)
