### PR TITLE
[FEATURE] AOP를 통해 해당 API에 대해 권한이 있는 Role인지 체크

### DIFF
--- a/src/main/java/com/flab/yousinsa/user/controller/annotation/RolePermission.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/annotation/RolePermission.java
@@ -1,0 +1,14 @@
+package com.flab.yousinsa.user.controller.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.flab.yousinsa.user.domain.enums.UserRole;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RolePermission {
+	UserRole[] permittedRoles();
+}

--- a/src/main/java/com/flab/yousinsa/user/controller/aop/AuthorizeAspect.java
+++ b/src/main/java/com/flab/yousinsa/user/controller/aop/AuthorizeAspect.java
@@ -1,0 +1,59 @@
+package com.flab.yousinsa.user.controller.aop;
+
+import static com.flab.yousinsa.global.config.AopAspectConfig.*;
+import static com.flab.yousinsa.user.controller.aop.AuthenticateAspect.*;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.flab.yousinsa.user.controller.annotation.RolePermission;
+import com.flab.yousinsa.user.domain.dtos.AuthUser;
+import com.flab.yousinsa.user.domain.enums.UserRole;
+import com.flab.yousinsa.user.service.exception.AuthorizationException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Aspect
+@Component
+@Order(AUTHORIZE_ASPECT_ORDER)
+public class AuthorizeAspect {
+
+	private final HttpServletRequest httpServletRequest;
+
+	@Around("@annotation(com.flab.yousinsa.user.controller.annotation.RolePermission)")
+	public Object authorizeByRole(final ProceedingJoinPoint pjp) throws Throwable {
+		HttpSession session = httpServletRequest.getSession(false);
+		AuthUser authUser = (AuthUser)session.getAttribute(AUTH_USER);
+
+		MethodSignature signature = (MethodSignature)(pjp.getSignature());
+		Method method = signature.getMethod();
+
+		RolePermission permissionAnnotation = method.getAnnotation(RolePermission.class);
+		UserRole[] permittedRoles = permissionAnnotation.permittedRoles();
+		log.debug(Arrays.toString(permittedRoles));
+
+		boolean isAuthorized = Arrays.stream(permittedRoles)
+			.anyMatch(permittedRole -> permittedRole.equals(authUser.getUserRole()));
+		log.debug(String.valueOf(isAuthorized));
+
+		if (!isAuthorized) {
+			log.debug("Requested Handler need " + Arrays.toString(permittedRoles));
+			throw new AuthorizationException("Requested handler need designated roles");
+		}
+
+		return pjp.proceed();
+	}
+}

--- a/src/main/java/com/flab/yousinsa/user/service/exception/AuthorizationException.java
+++ b/src/main/java/com/flab/yousinsa/user/service/exception/AuthorizationException.java
@@ -1,0 +1,19 @@
+package com.flab.yousinsa.user.service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class AuthorizationException extends RuntimeException {
+	public AuthorizationException(String message) {
+		super(message);
+	}
+
+	public AuthorizationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AuthorizationException(Throwable cause) {
+		super(cause);
+	}
+}


### PR DESCRIPTION
## 개요

- [x] Feature

## 작업 사항

- AOP를 사용하여 Authorization(권한 체크)를 구현했습니다.
  - AOP에서 Annotation을 Enum값을 받아 허락된 Role 중 로그인한 유저가 갖고 있는지 확인하는 형태로 구현했습니다.

- Authenticate 이후 Authorization을 수행하도록 Order를 통해 순서를 지정했습니다.